### PR TITLE
Add `yield` to infinite loop

### DIFF
--- a/word_blocks/06_control/04_control_forever.py
+++ b/word_blocks/06_control/04_control_forever.py
@@ -1,3 +1,4 @@
 # Control forever
 while True:
-    pass # replace with your code to repeat forever
+    # Put your code to repeat forever here, but keep next line. Otherwise, hub may become unresponsive.
+    yield


### PR DESCRIPTION
In case the loop doesn't do anything async, hub becomes unresponsive: it cannot stop program using central button, it doesn't react to stopping from the app. The only way to recover from such state is to power-cycle the hub. `yield` is a safety measure that ensures that hub has an opportunity to stop the program.

I've tested Mindstorms App 10.5.0 and this is what it produces for a program with empty infinite loop:

```python
from runtime import VirtualMachine

# When program starts
async def stack_1(vm, stack):
    # Control forever
    while True:
        yield

def setup(rpc, system, stop):
    vm = VirtualMachine(rpc, system, stop, "zT3_XLSwxzq9a3X2HyM_")

    vm.register_on_start("dN8usIOJtd8aD0BgPcv-", stack_1)

    return vm
```

I haven't checked, but possibly other kinds of loops also need this.